### PR TITLE
malloc: code cleanup

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -1,33 +1,39 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#define SIZE_GiB		(1ULL << 30)
+#define SIZE_TiB		(1ULL << 40)
+
+/* 2 ^ 47 = 256 TiB, split in half for user/kernel address space. */
+#define MAX_USER_VM_4LVL	(128ULL * SIZE_TiB)
+
 int main()
 {
+	int ret;
 	int i=0;
-	char *str;
-	//FILE *f;
-	//f = fopen("output.txt", "w");
-	/*if (f == NULL)
-	{
-		printf("Error opening file!\n");
-		exit(1);
-	}*/
+	void *ptr;
 
 	for (;;)
 	{
-		str = (char*) malloc(100000000);
-		if (str == NULL)
-		{
-			perror("malloc");
+		ptr = malloc(1 * SIZE_GiB);
+		if (ptr == NULL)
 			break;
-		}
-		i+=100;
-		
-		//fprintf(f,"%d \n",i);
-			
+		i++;
+	}
+	
+	printf("%d GiB allocated.\n",i);
+
+	if ((i * SIZE_GiB) > MAX_USER_VM_4LVL)
+	{
+		fprintf(stderr,
+			"Unexpected malloc total (%llu bytes > %llu bytes)\n",
+			i * SIZE_GiB, MAX_USER_VM_4LVL);
+		ret = EXIT_FAILURE;
+	}
+	else
+	{
+		ret = EXIT_SUCCESS;
 	}
 
-	
-	printf ("\n %d megabytes \n",i);
-	return 0;
+	return ret;
 }


### PR DESCRIPTION
Modify the malloc test program a little bit with the following cleanups:

- Use SIZE_GiB, SIZE_TiB, MAX_USER_VM_4LVL constants
- Increment memory in 1GiB chunks
- Only print out to stderr in case of unexpected results
- Use stdlib.h's EXIT_FAILURE, EXIT_SUCCESS macros