### PR TITLE
malloc: add test to run-tests

### DIFF
--- a/malloc.c
+++ b/malloc.c
@@ -2,14 +2,9 @@
 #include <stdlib.h>
 
 #define SIZE_GiB		(1ULL << 30)
-#define SIZE_TiB		(1ULL << 40)
-
-/* 2 ^ 47 = 256 TiB, split in half for user/kernel address space. */
-#define MAX_USER_VM_4LVL	(128ULL * SIZE_TiB)
 
 int main()
 {
-	int ret;
 	int i=0;
 	void *ptr;
 
@@ -23,17 +18,5 @@ int main()
 	
 	printf("%d GiB allocated.\n",i);
 
-	if ((i * SIZE_GiB) > MAX_USER_VM_4LVL)
-	{
-		fprintf(stderr,
-			"Unexpected malloc total (%llu bytes > %llu bytes)\n",
-			i * SIZE_GiB, MAX_USER_VM_4LVL);
-		ret = EXIT_FAILURE;
-	}
-	else
-	{
-		ret = EXIT_SUCCESS;
-	}
-
-	return ret;
+	return 0;
 }

--- a/run-tests
+++ b/run-tests
@@ -2,6 +2,8 @@
 
 EXPECT_5LVL=0
 
+MAX_USER_VM_4LVL_GiB=$(( 131072 ))
+
 #
 # Detect configuration
 #
@@ -34,4 +36,26 @@ if [[ $EXPECT_5LVL -eq 1 ]] ; then
 	echo "Expecting 5-level pagetables"
 else
 	echo "Expecting 4-level pagetables"
+fi
+
+
+#
+# malloc test
+#
+echo
+echo "Running malloc test... "
+regex="^([0-9]+) GiB allocated."
+output=$(./malloc)
+
+if [[ $? -ne 0 ]] ; then
+	echo "FAILED"
+elif [[ $output =~ $regex ]] ; then
+	alloc="${BASH_REMATCH[1]}"
+	if [[ $alloc -gt $MAX_USER_VM_4LVL_GiB ]] ; then
+		echo "$alloc GiB allocated > $MAX_USER_VM_4LVL_GiB GiB max 4-lvl user VM max"
+		echo "FAILED"
+	else
+		echo "$alloc GiB allocated <= $MAX_USER_VM_4LVL_GiB GiB max 4-lvl user VM max"
+		echo "PASS"
+	fi
 fi


### PR DESCRIPTION
This is a first effort to start calling the test programs from a centralized script.  Given issue #8 , I'm still not sure what the best policy is for reporting vs. detecting failures... however, this is my best initial stab at it:
  - test programs should only report facts
  - the running script should determine success / failure based on its calculated `EXPECT_5LVL` value

